### PR TITLE
Honor the users privacy decision and do not send UDP packets if he does not want to send metrics

### DIFF
--- a/gem/lib/capistrano-stats/metric-collector.rb
+++ b/gem/lib/capistrano-stats/metric-collector.rb
@@ -18,8 +18,8 @@ module Capistrano
     end
 
     def collect
+      return unless enabled?
       socket = UDPSocket.new
-      message.anonymize! unless enabled?
       socket.send(message.to_s, 0, *destination)
     rescue SocketError
       warn "There was a problem tracking statistics, please report to https://github.com/capistrano/stats"


### PR DESCRIPTION
Hi, if the user does not want to send metrics and answers N to your question, you should honor that decision.
Instead what you are doing is, you still send metrics, but replace the fields in the hash with "anonymous".
Let me tell you: I don't want to send metrics, not even metrics with fields filled with "anonymous".
Not wanting to send metrics does NOT mean: Please collect my IP address, time and date whenever I deploy something, it means: Do not send anything to the metrics server!
I corrected the collect function. It now exits if the user did not want to send metrics.
Regards, Clemens
