### PR TITLE
Document how to disable capistrano stats collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,16 @@ with both version two and three for testing purposes:
       ** Execute default
       ** Invoke load:defaults (first_time)
       ** Execute load:defaults
+
+## Disable Statistics Collection
+
+The initial statistics collection prompt may break your automated build or
+deployment systems. If you would like to disable the collection you can create
+a .capstrano folder in your project and a file within called metrics with the
+content "false"
+
+```
+cd <project directory>
+mkdir .capistrano
+echo "false" > .capistrano/metrics
+```


### PR DESCRIPTION
Automated build and deployment systems may break on the prompt for input.
Having some documentation about this in the README.md is going to save
everyone some time.

Ideally the default behaviour is going to disable stats collection and
require it to be explicitly enabled.
